### PR TITLE
chore: update docker workflow branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ name: Docker
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - 'v*.*.*'
   workflow_dispatch:
@@ -13,7 +13,7 @@ on:
 jobs:
   build-and-push:
     name: Build and Push
-    uses: durabilitylabs/github-actions/.github/workflows/docker-reusable.yml@master
+    uses: durability-labs/github-actions/.github/workflows/docker-reusable.yml@main
     with:
       docker_file: docker/crawler.Dockerfile
       dockerhub_repo: durabilitylabs/archivist-network-crawler


### PR DESCRIPTION
PR updates Docker workflow and we have to trigger it on a default branch, which is `main` and reusable workflow branch is `main` as well.